### PR TITLE
feat: Implement new interactive commands and settings persistence

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -57,6 +58,7 @@ type Settings struct {
 	Stream           bool    `json:"stream"`
 	ReasoningEffort  string  `json:"reasoning_effort"`
 	Stop             string  `json:"stop,omitempty"`
+	HistoryLimit     int     `json:"history_limit,omitempty"`
 }
 
 type Message struct {
@@ -298,6 +300,7 @@ func persistSettingsToFile(path string, cfg map[string]string) error {
 		MaxTokens:        mustAtoi(cfg["MAX_TOKENS"], 4096),
 		Stream:           stream,
 		ReasoningEffort:  cfg["REASONING_EFFORT"],
+		HistoryLimit:     mustAtoi(cfg["HISTORY_LIMIT"], defaultHistoryLimit),
 	}
 	if cfg["STOP"] != "" {
 		s.Stop = cfg["STOP"]
@@ -342,6 +345,9 @@ func applyFileSettingsAsDefaults(path string, cfg map[string]string, provided ma
 	}
 	if !provided["STOP"] && cf.Settings.Stop != "" {
 		cfg["STOP"] = cf.Settings.Stop
+	}
+	if !provided["HISTORY_LIMIT"] && cf.Settings.HistoryLimit != 0 {
+		cfg["HISTORY_LIMIT"] = fmt.Sprintf("%d", cf.Settings.HistoryLimit)
 	}
 	return nil
 }
@@ -668,6 +674,7 @@ func openTTY() (*os.File, error) {
 }
 
 func main() {
+	rand.Seed(time.Now().UnixNano())
 	// Default cfg map
 	cfg := map[string]string{
 		"BASE_URL":          defaultBaseURL,
@@ -688,7 +695,8 @@ func main() {
 	// Parse options (robust)
 	// -----------------------
 	provided := map[string]bool{}
-	args := os.Args[1:]
+	rawArgs := os.Args[1:]
+	var positionalArgs []string
 
 	ACCESS_TOKEN := ""
 	SYS_PROMPT_FILE := ""
@@ -700,234 +708,202 @@ func main() {
 	// helper to get next argument (used when flag and its value are separate tokens)
 	nextArg := func(i *int) (string, error) {
 		*i++
-		if *i >= len(args) {
-			return "", fmt.Errorf("missing value for %s", args[*i-1])
+		if *i >= len(rawArgs) {
+			return "", fmt.Errorf("missing value for %s", rawArgs[*i-1])
 		}
-		return args[*i], nil
+		return rawArgs[*i], nil
 	}
 
 	i := 0
-parseLoop:
-	for i < len(args) {
-		a := args[i]
+	for i < len(rawArgs) {
+		a := rawArgs[i]
 
-		// support --flag=value and -f=value
-		if strings.HasPrefix(a, "--") {
-			kv := strings.SplitN(a, "=", 2)
-			key := kv[0]
-			val := ""
-			if len(kv) == 2 {
-				val = kv[1]
+		if a == "--" {
+			// stop parsing flags; remaining args are positional
+			positionalArgs = append(positionalArgs, rawArgs[i+1:]...)
+			break
+		}
+
+		if !strings.HasPrefix(a, "-") {
+			positionalArgs = append(positionalArgs, a)
+			i++
+			continue
+		}
+
+		// at this point, 'a' is a flag
+		key := a
+		val := ""
+		// handle --flag=value and -f=value
+		if strings.Contains(a, "=") {
+			parts := strings.SplitN(a, "=", 2)
+			key = parts[0]
+			val = parts[1]
+		}
+
+		switch key {
+		// flags that take a value
+		case "-m", "--model":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
 			}
-			switch key {
-			case "--reasoning":
-				if val == "" {
-					v, err := nextArg(&i)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-						os.Exit(1)
-					}
-					val = v
+			cfg["MODEL"] = val
+			provided["MODEL"] = true
+		case "-T", "--temperature":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
 				}
-				cfg["REASONING_EFFORT"] = val
-				provided["REASONING_EFFORT"] = true
-			case "--stop":
-				if val == "" {
-					v, err := nextArg(&i)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-						os.Exit(1)
-					}
-					val = v
+				val = v
+			}
+			cfg["TEMPERATURE"] = val
+			provided["TEMPERATURE"] = true
+		case "-P", "--top_p":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
 				}
-				cfg["STOP"] = val
-				provided["STOP"] = true
-			case "--prompt":
-				if val == "" {
-					v, err := nextArg(&i)
-					if err != nil {
-						fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-						os.Exit(1)
-					}
-					val = v
+				val = v
+			}
+			cfg["TOP_P"] = val
+			provided["TOP_P"] = true
+		case "-f", "--frequency_penalty":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
 				}
-				PROMPT_MODE = val
-			case "--no-stream":
-				cfg["STREAM"] = "false"
-				provided["STREAM"] = true
-			case "--stream=true":
+				val = v
+			}
+			cfg["FREQUENCY_PENALTY"] = val
+			provided["FREQUENCY_PENALTY"] = true
+		case "-r", "--presence_penalty":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			cfg["PRESENCE_PENALTY"] = val
+			provided["PRESENCE_PENALTY"] = true
+		case "-M", "--max_tokens":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			cfg["MAX_TOKENS"] = val
+			provided["MAX_TOKENS"] = true
+		case "-L", "--limit":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			cfg["HISTORY_LIMIT"] = val
+			provided["HISTORY_LIMIT"] = true
+		case "-s", "--sys_prompt_file":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			SYS_PROMPT_FILE = val
+			provided["SYS_PROMPT_FILE"] = true
+		case "-k", "--access_token":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			ACCESS_TOKEN = val
+		case "--reasoning":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			cfg["REASONING_EFFORT"] = val
+			provided["REASONING_EFFORT"] = true
+		case "--stop":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			cfg["STOP"] = val
+			provided["STOP"] = true
+		case "--prompt":
+			if val == "" {
+				v, err := nextArg(&i)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+					os.Exit(1)
+				}
+				val = v
+			}
+			PROMPT_MODE = val
+		case "--stream":
+			if val == "true" {
 				cfg["STREAM"] = "true"
-				provided["STREAM"] = true
-			case "--stream=false":
+			} else if val == "false" {
 				cfg["STREAM"] = "false"
-				provided["STREAM"] = true
-			case "--save-settings":
-				SAVE_SETTINGS = true
-			case "--list":
-				LIST_ONLY = true
-			case "--help":
-				printHelp(cfg)
-				return
-			case "--":
-				// stop parsing flags; remaining args are positional
-				i++
-				break parseLoop
-			default:
-				// If it's --flag=value form but unknown, error out
-				if strings.Contains(a, "=") {
-					fmt.Fprintf(os.Stderr, "Unknown option: %s\n", key)
-					printHelp(cfg)
-					os.Exit(1)
-				}
-				// unknown long flag without equals: error
-				fmt.Fprintf(os.Stderr, "Unknown option: %s\n", key)
-				printHelp(cfg)
+			} else {
+				fmt.Fprintf(os.Stderr, "%sInvalid value for --stream: %s. Use true or false.%s\n", red, val, normal)
 				os.Exit(1)
 			}
-			i++
-			continue
+			provided["STREAM"] = true
+
+		// boolean flags
+		case "-S":
+			PERSIST_SYSTEM = true
+		case "--no-stream":
+			cfg["STREAM"] = "false"
+			provided["STREAM"] = true
+		case "--save-settings":
+			SAVE_SETTINGS = true
+		case "-l", "--list":
+			LIST_ONLY = true
+		case "-h", "--help":
+			printHelp(cfg)
+			return
+		default:
+			fmt.Fprintf(os.Stderr, "Unknown option: %s\n", a)
+			printHelp(cfg)
+			os.Exit(1)
 		}
-
-		// short options like -m value or -m=value, -h
-		if strings.HasPrefix(a, "-") {
-			// handle known single-letter flags
-			// also accept -h and -l etc.
-			if a == "-h" || a == "--help" {
-				printHelp(cfg)
-				return
-			}
-			// support -m=value
-			if strings.Contains(a, "=") {
-				kv := strings.SplitN(a, "=", 2)
-				key := kv[0]
-				val := kv[1]
-				switch key {
-				case "-m":
-					cfg["MODEL"] = val
-					provided["MODEL"] = true
-				case "-T":
-					cfg["TEMPERATURE"] = val
-					provided["TEMPERATURE"] = true
-				case "-P":
-					cfg["TOP_P"] = val
-					provided["TOP_P"] = true
-				case "-f":
-					cfg["FREQUENCY_PENALTY"] = val
-					provided["FREQUENCY_PENALTY"] = true
-				case "-r":
-					cfg["PRESENCE_PENALTY"] = val
-					provided["PRESENCE_PENALTY"] = true
-				case "-M":
-					cfg["MAX_TOKENS"] = val
-					provided["MAX_TOKENS"] = true
-				case "-L":
-					cfg["HISTORY_LIMIT"] = val
-					provided["HISTORY_LIMIT"] = true
-				case "-s":
-					SYS_PROMPT_FILE = val
-					provided["SYS_PROMPT_FILE"] = true
-				case "-k":
-					ACCESS_TOKEN = val
-				default:
-					fmt.Fprintf(os.Stderr, "Unknown option: %s\n", key)
-					printHelp(cfg)
-					os.Exit(1)
-				}
-				i++
-				continue
-			}
-
-			// known single-letter flags that require a next token
-			switch a {
-			case "-m":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["MODEL"] = v
-				provided["MODEL"] = true
-			case "-T":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["TEMPERATURE"] = v
-				provided["TEMPERATURE"] = true
-			case "-P":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["TOP_P"] = v
-				provided["TOP_P"] = true
-			case "-f":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["FREQUENCY_PENALTY"] = v
-				provided["FREQUENCY_PENALTY"] = true
-			case "-r":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["PRESENCE_PENALTY"] = v
-				provided["PRESENCE_PENALTY"] = true
-			case "-M":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["MAX_TOKENS"] = v
-				provided["MAX_TOKENS"] = true
-			case "-L":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				cfg["HISTORY_LIMIT"] = v
-				provided["HISTORY_LIMIT"] = true
-			case "-s":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				SYS_PROMPT_FILE = v
-				provided["SYS_PROMPT_FILE"] = true
-			case "-k":
-				v, err := nextArg(&i)
-				if err != nil {
-					fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
-					os.Exit(1)
-				}
-				ACCESS_TOKEN = v
-			case "-l":
-				LIST_ONLY = true
-			default:
-				// unknown short option -> error
-				fmt.Fprintf(os.Stderr, "Unknown option: %s\n", a)
-				printHelp(cfg)
-				os.Exit(1)
-			}
-			i++
-			continue
-		}
-
-		// Positional argument -> remainder are positional (conversation file and beyond)
-		// stop parsing and treat rest as positional
-		args = args[i:]
-		break
+		i++
 	}
-	// after parsing, 'args' contains the leftover positional arguments
+	args := positionalArgs
 
 	// If list requested
 	if LIST_ONLY {
@@ -947,6 +923,28 @@ parseLoop:
 	if ACCESS_TOKEN == "" {
 		fmt.Fprintf(os.Stderr, "%sNo API key provided.%s Set NVIDIA_BUILD_AI_ACCESS_TOKEN or pass -k ACCESS_TOKEN\n", red, normal)
 		os.Exit(1)
+	}
+
+	// conversation file
+	convFile := ""
+	if len(args) > 0 {
+		convFile = args[0]
+		// expand ~
+		if strings.HasPrefix(convFile, "~") {
+			home := os.Getenv("HOME")
+			convFile = home + convFile[1:]
+		}
+	}
+
+	// read system prompt file
+	sysPromptContent := ""
+	if SYS_PROMPT_FILE != "" {
+		if _, err := os.Stat(SYS_PROMPT_FILE); os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "%sSystem prompt file not found: %s%s\n", red, SYS_PROMPT_FILE, normal)
+			os.Exit(1)
+		}
+		b, _ := ioutil.ReadFile(SYS_PROMPT_FILE)
+		sysPromptContent = string(b)
 	}
 
 	// Non-interactive prompt mode
@@ -974,24 +972,44 @@ parseLoop:
 			promptText = PROMPT_MODE
 		}
 
-		err = processSinglePrompt(promptText, cfg, "", ACCESS_TOKEN)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%sError: %v%s\n", red, err, normal)
-			os.Exit(1)
+		if convFile != "" {
+			// Non-interactive with a conversation file
+			if err := ensureHistoryFileStructure(convFile, cfg); err != nil {
+				fmt.Fprintf(os.Stderr, "%sFailed to setup conversation file: %v%s\n", red, err, normal)
+				os.Exit(1)
+			}
+			if err := applyFileSettingsAsDefaults(convFile, cfg, provided); err != nil {
+				fmt.Fprintf(os.Stderr, "%sWarning applying file settings: %v%s\n", red, err, normal)
+			}
+			if err := validateNumericRanges(cfg); err != nil {
+				fmt.Fprintf(os.Stderr, "%s%s%s\n", red, err.Error(), normal)
+				os.Exit(1)
+			}
+			if SAVE_SETTINGS {
+				if err := persistSettingsToFile(convFile, cfg); err != nil {
+					fmt.Fprintf(os.Stderr, "%sFailed to persist settings: %v%s\n", red, err, normal)
+					os.Exit(1)
+				}
+				fmt.Fprintf(os.Stderr, "%sPersisted current settings into %s%s\n", green, convFile, normal)
+			}
+			err = processMessage(promptText, convFile, cfg, sysPromptContent, ACCESS_TOKEN)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%sError: %v%s\n", red, err, normal)
+				os.Exit(1)
+			}
+		} else {
+			// Non-interactive, no conversation file
+			err = processSinglePrompt(promptText, cfg, sysPromptContent, ACCESS_TOKEN)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%sError: %v%s\n", red, err, normal)
+				os.Exit(1)
+			}
 		}
 		return
 	}
 
-	// conversation file
-	convFile := ""
-	if len(args) > 0 {
-		convFile = args[0]
-		// expand ~
-		if strings.HasPrefix(convFile, "~") {
-			home := os.Getenv("HOME")
-			convFile = home + convFile[1:]
-		}
-	} else {
+	// Interactive mode
+	if convFile == "" {
 		// create new default path
 		hdir := os.Getenv("XDG_CACHE_HOME")
 		if hdir == "" {
@@ -1009,17 +1027,6 @@ parseLoop:
 		os.Exit(1)
 	}
 	fmt.Fprintf(os.Stderr, "%sConversation file:%s %s\n", green, normal, convFile)
-
-	// read system prompt file
-	sysPromptContent := ""
-	if SYS_PROMPT_FILE != "" {
-		if _, err := os.Stat(SYS_PROMPT_FILE); os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "%sSystem prompt file not found: %s%s\n", red, SYS_PROMPT_FILE, normal)
-			os.Exit(1)
-		}
-		b, _ := ioutil.ReadFile(SYS_PROMPT_FILE)
-		sysPromptContent = string(b)
-	}
 
 	// Apply persisted settings as defaults if user did not provide those options explicitly
 	if err := applyFileSettingsAsDefaults(convFile, cfg, provided); err != nil {
@@ -1080,7 +1087,7 @@ the risk of any harm caused by any response or output of the model. Please
 do not upload any confidential information or personal data unless
 expressly permitted. Your use is logged for security purposes.
 `)
-	fmt.Fprintf(os.Stderr, "%sNVIDIA chat (go)%s model=%s temperature=%s top_p=%s max_tokens=%s stream=%s\n", bold, normal, cfg["MODEL"], cfg["TEMPERATURE"], cfg["TOP_P"], cfg["MAX_TOKENS"], cfg["STREAM"])
+	fmt.Fprintf(os.Stderr, "%sNVIDIA chat (go)%s model=%s temperature=%s top_p=%s max_tokens=%s stream=%s freq_penalty=%s pres_penalty=%s reasoning=%s stop=%q\n", bold, normal, cfg["MODEL"], cfg["TEMPERATURE"], cfg["TOP_P"], cfg["MAX_TOKENS"], cfg["STREAM"], cfg["FREQUENCY_PENALTY"], cfg["PRESENCE_PENALTY"], cfg["REASONING_EFFORT"], cfg["STOP"])
 	fmt.Fprintf(os.Stderr, "Conversation file: %s\n", convFile)
 	fmt.Fprintln(os.Stderr, "Type your message and end it by Ctrl+D. Commands: /exit /quit /history /clear /save <file> /persist-system (see help)")
 
@@ -1234,6 +1241,35 @@ expressly permitted. Your use is logged for security purposes.
 // Returns true if the command was a special/handled interactive command
 // handleInteractiveInput returns true if the input was a special command that was handled here.
 // Otherwise returns false so the caller will continue normal message processing.
+func exportLastN(n int, convFile, targetFile string) error {
+	cf, err := readConversation(convFile)
+	if err != nil {
+		return fmt.Errorf("reading conversation file: %w", err)
+	}
+
+	var aiResponses []string
+	for i := len(cf.Messages) - 1; i >= 0; i-- {
+		if cf.Messages[i].Role == "assistant" {
+			aiResponses = append(aiResponses, cf.Messages[i].Content)
+			if len(aiResponses) == n {
+				break
+			}
+		}
+	}
+
+	if len(aiResponses) == 0 {
+		return fmt.Errorf("no assistant responses found")
+	}
+
+	// Reverse the slice to get the correct order
+	for i, j := 0, len(aiResponses)-1; i < j; i, j = i+1, j-1 {
+		aiResponses[i], aiResponses[j] = aiResponses[j], aiResponses[i]
+	}
+
+	content := strings.Join(aiResponses, "\n\n---\n\n")
+	return ioutil.WriteFile(targetFile, []byte(content), 0o644)
+}
+
 func handleInteractiveInput(userInput, convFile string, cfg map[string]string) bool {
 	trimmed := strings.TrimSpace(userInput)
 	parts := strings.Fields(trimmed)
@@ -1286,28 +1322,28 @@ func handleInteractiveInput(userInput, convFile string, cfg map[string]string) b
 		return true
 
 	case "/persist-system":
-		fmt.Fprint(os.Stderr, "Path to system prompt file to persist: ")
-		tty, err := openTTY()
+		if len(parts) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: /persist-system <file>")
+			return true
+		}
+		path := parts[1]
+		if !fileExists(path) {
+			fmt.Fprintf(os.Stderr, "%sFile not found: %s%s\n", red, path, normal)
+			return true
+		}
+		content, err := ioutil.ReadFile(path)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%sNo TTY available to read path%s\n", red, normal)
+			fmt.Fprintf(os.Stderr, "%sFailed to read file: %v%s\n", red, err, normal)
 			return true
 		}
-		b, _ := ioutil.ReadAll(tty)
-		tty.Close()
-		path := strings.TrimSpace(string(b))
-		if path == "" || !fileExists(path) {
-			fmt.Fprintf(os.Stderr, "%sFile not found%s\n", red, normal)
-			return true
-		}
-		content, _ := ioutil.ReadFile(path)
 		if err := persistSystemToFile(convFile, string(content)); err != nil {
 			fmt.Fprintf(os.Stderr, "%sFailed to persist system prompt: %v%s\n", red, err, normal)
 		} else {
-			fmt.Fprintf(os.Stderr, "%sPersisted system prompt into conversation file's .system%s\n", green, normal)
+			fmt.Fprintf(os.Stderr, "%sPersisted system prompt from %s into conversation file's .system%s\n", green, path, normal)
 		}
 		return true
 
-	case "/model", "/temperature", "/top_p", "/frequency_penalty", "/presence_penalty", "/max_tokens", "/reasoning", "/stop":
+	case "/model", "/temperature", "/top_p", "/frequency_penalty", "/presence_penalty", "/max_tokens", "/reasoning", "/stop", "/limit", "/stream":
 		if len(parts) < 2 {
 			fmt.Fprintf(os.Stderr, "Usage: %s <value>\n", command)
 			return true
@@ -1317,6 +1353,9 @@ func handleInteractiveInput(userInput, convFile string, cfg map[string]string) b
 		key = strings.ToUpper(key)
 		if key == "REASONING" {
 			key = "REASONING_EFFORT"
+		}
+		if key == "LIMIT" {
+			key = "HISTORY_LIMIT"
 		}
 		// quick validation
 		tempCfg := make(map[string]string)
@@ -1338,6 +1377,60 @@ func handleInteractiveInput(userInput, convFile string, cfg map[string]string) b
 		} else {
 			fmt.Fprintf(os.Stderr, "%sPersisted current settings to %s%s\n", green, convFile, normal)
 		}
+		return true
+	case "/exportlast":
+		if len(parts) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: /exportlast <file>")
+			return true
+		}
+		targetFile := parts[1]
+		if err := exportLastN(1, convFile, targetFile); err != nil {
+			fmt.Fprintf(os.Stderr, "%sFailed to export: %v%s\n", red, err, normal)
+		} else {
+			fmt.Fprintf(os.Stderr, "%sExported last response to %s%s\n", green, targetFile, normal)
+		}
+		return true
+	case "/exportn":
+		if len(parts) < 3 {
+			fmt.Fprintln(os.Stderr, "Usage: /exportn <n> <file>")
+			return true
+		}
+		n, err := strconv.Atoi(parts[1])
+		if err != nil || n <= 0 {
+			fmt.Fprintf(os.Stderr, "%sInvalid number: %s%s\n", red, parts[1], normal)
+			return true
+		}
+		targetFile := parts[2]
+		if err := exportLastN(n, convFile, targetFile); err != nil {
+			fmt.Fprintf(os.Stderr, "%sFailed to export: %v%s\n", red, err, normal)
+		} else {
+			fmt.Fprintf(os.Stderr, "%sExported last %d responses to %s%s\n", green, n, targetFile, normal)
+		}
+		return true
+	case "/randomodel":
+		newModel := modelsList[rand.Intn(len(modelsList))]
+		cfg["MODEL"] = newModel
+		fmt.Fprintf(os.Stderr, "%sSwitched model to %s%s\n", green, newModel, normal)
+		return true
+	case "/help":
+		fmt.Fprintln(os.Stderr, "Available commands:")
+		fmt.Fprintln(os.Stderr, "  /exit, /quit: Exit the program")
+		fmt.Fprintln(os.Stderr, "  /history: Print full conversation JSON")
+		fmt.Fprintln(os.Stderr, "  /clear: Clear conversation messages")
+		fmt.Fprintln(os.Stderr, "  /save <file>: Save conversation to a new file")
+		fmt.Fprintln(os.Stderr, "  /persist-system <file>: Persist a system prompt from a file")
+		fmt.Fprintln(os.Stderr, "  /model <model_name>: Switch model for this session")
+		fmt.Fprintln(os.Stderr, "  /temperature <0..1>: Set temperature for this session")
+		fmt.Fprintln(os.Stderr, "  /top_p <0.01..1>: Set top_p for this session")
+		fmt.Fprintln(os.Stderr, "  /max_tokens <1..4096>: Set max_tokens for this session")
+		fmt.Fprintln(os.Stderr, "  /stop <string>: Set stop string for this session")
+		fmt.Fprintln(os.Stderr, "  /limit <number>: Set history limit for this session")
+		fmt.Fprintln(os.Stderr, "  /stream <true|false>: Enable/disable streaming for this session")
+		fmt.Fprintln(os.Stderr, "  /persist-settings: Save the current session's settings to the conversation file")
+		fmt.Fprintln(os.Stderr, "  /exportlast <file>: Export last AI response to a markdown file")
+		fmt.Fprintln(os.Stderr, "  /exportn <n> <file>: Export last n AI responses to a markdown file")
+		fmt.Fprintln(os.Stderr, "  /randomodel: Switch to a random model")
+		fmt.Fprintln(os.Stderr, "  /help: Show this help message")
 		return true
 
 	default:


### PR DESCRIPTION
This commit introduces a number of new features and improvements to the interactive mode of the chat tool.

- Adds a `/limit` command to change the history limit.
- Adds a `/stream` command to toggle streaming.
- Updates `/persist-system` to accept a file path directly.
- Adds `/exportlast` and `/exportn` to export AI responses to markdown.
- Adds a `/randomodel` command to switch to a random model.
- Adds a `/help` command to list all interactive commands.
- Ensures that the history limit setting (`-L`) is saved and loaded when using `--save-settings` or `/persist-settings`.