### PR TITLE
feat: Add GitHub Actions for CI and Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.20'
+
+    - name: Build
+      run: make build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - name: Build for all platforms
+        run: |
+          make build-linux
+          make build-windows
+          make build-macos
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            nvidia-ai-chat-linux-amd64
+            nvidia-ai-chat-windows-amd64.exe
+            nvidia-ai-chat-darwin-amd64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,19 @@ run: build
 
 clean:
 	@echo "Cleaning up..."
-	rm -f $(APP_NAME) $(APP_NAME).exe
+	rm -f $(APP_NAME) $(APP_NAME).exe nvidia-ai-chat-*-amd64 nvidia-ai-chat-*-amd64.exe
+
+.PHONY: build-linux build-windows build-macos
+
+build-linux:
+	@echo "Building for Linux (amd64)..."
+	GOOS=linux GOARCH=amd64 go build -o nvidia-ai-chat-linux-amd64 .
+
+build-windows:
+	@echo "Building for Windows (amd64)..."
+	GOOS=windows GOARCH=amd64 go build -o nvidia-ai-chat-windows-amd64.exe .
+
+build-macos:
+	@echo "Building for macOS (amd64)..."
+	GOOS=darwin GOARCH=amd64 go build -o nvidia-ai-chat-darwin-amd64 .
 


### PR DESCRIPTION
This commit introduces two new GitHub Actions workflows:
- `ci.yml`: Builds the application on every push to `main` and on pull requests targeting `main`.
- `release.yml`: Builds the application for Linux, Windows, and macOS, and creates a GitHub Release with the binaries when a version tag is pushed.

The `Makefile` has been updated to support cross-platform builds.